### PR TITLE
fix: brings tracelog into response to send it back to client

### DIFF
--- a/cactus-system/cactus-interpreter/src/cactus_resp.rs
+++ b/cactus-system/cactus-interpreter/src/cactus_resp.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use tracing::{info, warn};
 
 const STATUS_ID: &str = "_status_code";
 const PAYLOAD_ID: &str = "_payload";
@@ -41,6 +42,6 @@ impl Into<CactusResponse> for Value {
             }
             _ => {}
         };
-        CactusResponse::error("error whilst casting into CactusResponse".to_string())
+        CactusResponse::error(self.to_string())
     }
 }


### PR DESCRIPTION
This PR fixes #38.

It adds (details) tracelog into response in the event of an 5XX error been thrown.

Option to disable tracelog could be implemented later. (created under #40)